### PR TITLE
Adds the ability to parse json api body scheme

### DIFF
--- a/src/Middleware/LoggerMiddleware.php
+++ b/src/Middleware/LoggerMiddleware.php
@@ -292,7 +292,7 @@ class LoggerMiddleware
         }
 
         $body = $stream->getContents();
-        $isJson = preg_grep('/application\/json/', $message->getHeader('Content-Type'));
+        $isJson = preg_grep('/application\/[\w\.\+]*(json)/', $message->getHeader('Content-Type'));
         if (!empty($isJson)) {
             $body = json_decode($body, true);
         }

--- a/tests/Unit/LoggerMiddlewareTest.php
+++ b/tests/Unit/LoggerMiddlewareTest.php
@@ -210,6 +210,32 @@ class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function logTransactionWithJsonApiResponse()
+    {
+        $headers = [
+            'Content-Type' => 'application/vnd.api+json',
+        ];
+        $this->appendResponse(200, $headers, '{"status": true, "client": 13000}')
+            ->getClient(['exceptions' => false])
+            ->get('/');
+
+        $this->assertCount(2, $this->logger->history);
+        $this->assertSame('debug', $this->logger->history[0]['level']);
+        $this->assertSame('Guzzle HTTP request', $this->logger->history[0]['message']);
+        $this->assertSame('debug', $this->logger->history[1]['level']);
+        $this->assertSame('Guzzle HTTP response', $this->logger->history[1]['message']);
+        $this->assertContains(
+            [
+                'status' => true,
+                'client' => 13000,
+            ],
+            $this->logger->history[1]['context']['response']['body']
+        );
+    }
+
+    /**
+     * @test
+     */
     public function logTransactionWithTransferException()
     {
         try {


### PR DESCRIPTION
Given json api scheme uses a different header [Content Negotiation Json Api](http://jsonapi.org/format/#content-negotiation), the body was being rejected from a valid json body.

This PR adds the ability to accept `application/json` & `application/vnd.api+json` as content types