### PR TITLE
Fix meaning of exception only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to `gmponos/guzzle_logger` will be documented in this file
 
+## 0.5.0 - 2018-10-01
+
+### Changed
+- Renamed the variable `$logRequestOnExceptionOnly` to `$onExceptionOnly`. The purpose of this constructor argument was 
+to log request and responses only if an exception occurs.
+- Deprecated the option `requests`. It will be removed on my next version.
+
 ## 0.4.0 - 2018-09-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All Notable changes to `gmponos/guzzle_logger` will be documented in this file
 ## 0.5.0 - 2018-10-01
 
 ### Changed
-- Renamed the variable `$logRequestOnExceptionOnly` to `$onExceptionOnly`. The purpose of this constructor argument was 
-to log request and responses only if an exception occurs.
+- **BREAKING CHANGE** Renamed the variable `$logRequestOnExceptionOnly` to `$onExceptionOnly`. The purpose of this constructor argument was 
+to log request and responses only if an exceptgition occurs. If you were manually setting this argument as true now you must set it
+as false as the variables meaning is inverted.
 - Deprecated the option `requests`. It will be removed on my next version.
 
 ## 0.4.0 - 2018-09-12

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The signature of the LoggerMiddleware class is the following:
 ``LoggerMiddleware(LoggerInterface $logger, $logRequests = true, $logStatistics = false, array $thresholds = [])``
 
 - **logger** - The PSR-3 logger to use for logging.
-- **logRequests** - By default the middleware is set to log every request and response. If you wish that to log only the requests and responses that you retrieve a status code above 4xx set this as false.
+- **$onExceptionOnly** - By default the middleware is set to log every request and response. If you wish that to log only the requests and responses that you retrieve a status code above 4xx set this as true.
 - **logStatistics** - If you set logStatistics as true and this as true then guzzle will also log statistics about the requests.
 - **thresholds** - An array that you may use to change the thresholds of logging the responses. 
 
@@ -66,7 +66,7 @@ You can set on each request options about your log.
 ```php
 $client->get("/", [
     'log' => [
-        'requests' => true,
+        'on_exception_only' => true,
         'statistics' => true,
         'error_threshold' => null,
         'warning_threshold' => null,
@@ -81,8 +81,8 @@ $client->get("/", [
 ```
 
 - ``sensitive`` if you set this to true then the body of request/response will not be logged as it will be considered that it contains sensitive information.
-- ``requests`` Do not log anything unless if the request is above the threshold or inside the levels.
-- ``statistics`` if the requests variable is true and this is also true the logger will log statistics about the request
+- ``on_exception_only`` Do not log anything unless if the response status code is above the threshold.
+- ``statistics`` if the `on_exception_only` option/variable is true and this is also true the middleware will log statistics about the HTTP call.
 - ``levels`` set custom log levels for each response status code
 
 ## Change log

--- a/tests/TestApp/HistoryLogger.php
+++ b/tests/TestApp/HistoryLogger.php
@@ -6,7 +6,6 @@ use Psr\Log\LoggerInterface;
 
 class HistoryLogger implements LoggerInterface
 {
-
     /**
      * @var array
      */
@@ -16,7 +15,7 @@ class HistoryLogger implements LoggerInterface
      * System is unusable.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      * @return void
      */
     public function emergency($message, array $context = [])
@@ -35,7 +34,7 @@ class HistoryLogger implements LoggerInterface
      * trigger the SMS alerts and wake you up.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      * @return void
      */
     public function alert($message, array $context = [])
@@ -53,7 +52,7 @@ class HistoryLogger implements LoggerInterface
      * Example: Application component unavailable, unexpected exception.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      * @return void
      */
     public function critical($message, array $context = [])
@@ -70,7 +69,7 @@ class HistoryLogger implements LoggerInterface
      * be logged and monitored.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      * @return void
      */
     public function error($message, array $context = [])
@@ -89,7 +88,7 @@ class HistoryLogger implements LoggerInterface
      * that are not necessarily wrong.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      * @return void
      */
     public function warning($message, array $context = [])
@@ -105,7 +104,7 @@ class HistoryLogger implements LoggerInterface
      * Normal but significant events.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      * @return void
      */
     public function notice($message, array $context = [])
@@ -123,7 +122,7 @@ class HistoryLogger implements LoggerInterface
      * Example: User logs in, SQL logs.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      * @return void
      */
     public function info($message, array $context = [])
@@ -139,7 +138,7 @@ class HistoryLogger implements LoggerInterface
      * Detailed debug information.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      * @return void
      */
     public function debug($message, array $context = [])
@@ -154,9 +153,9 @@ class HistoryLogger implements LoggerInterface
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed  $level
+     * @param mixed $level
      * @param string $message
-     * @param array  $context
+     * @param array $context
      * @return void
      */
     public function log($level, $message, array $context = [])
@@ -166,5 +165,13 @@ class HistoryLogger implements LoggerInterface
             'message' => $message,
             'context' => $context,
         ];
+    }
+
+    /**
+     * Cleans the history of the logger.
+     */
+    public function clean()
+    {
+        $this->history = [];
     }
 }

--- a/tests/Unit/LoggerMiddlewareTest.php
+++ b/tests/Unit/LoggerMiddlewareTest.php
@@ -85,7 +85,7 @@ final class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function doNotLogSuccessfulTransaction()
+    public function logOnlyResponseWhenLogRequestsIsSetToFalse()
     {
         $this->appendResponse(200)
             ->createClient([
@@ -94,6 +94,17 @@ final class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
                 ],
             ])
             ->get('/');
+
+        $this->assertCount(0, $this->logger->history);
+
+        $this->logger->clean();
+
+        $this->appendResponse(200)->createClient()
+            ->get('/', [
+                'log' => [
+                    'requests' => false,
+                ],
+            ]);
 
         $this->assertCount(0, $this->logger->history);
     }


### PR DESCRIPTION
### Changed
- **BREAKING CHANGE** Renamed the variable `$logRequestOnExceptionOnly` to `$onExceptionOnly`. The purpose of this constructor argument was 
to log request and responses only if an exceptgition occurs. If you were manually setting this argument as true now you must set it
as false as the variables meaning is inverted.
- Deprecated the option `requests`. It will be removed on my next version.