### PR TITLE
Created custom handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to `gmponos/guzzle_logger` will be documented in this file
 
+## 0.6.0 - 2018-10-15
+
+### Changed
+- **BREAKING CHANGE** Changed the constructor function of middleware.
+    - From now on you can pass a handler to it's constructor. Handlers are responsible for logging request/responses.
+    - Removed threshold argument.
+
 ## 0.5.0 - 2018-10-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All Notable changes to `gmponos/guzzle_logger` will be documented in this file
 
 ### Changed
 - **BREAKING CHANGE** Renamed the variable `$logRequestOnExceptionOnly` to `$onExceptionOnly`. The purpose of this constructor argument was 
-to log request and responses only if an exceptgition occurs. If you were manually setting this argument as true now you must set it
+to log request and responses only if an exception occurs. If you were manually setting this argument as true now you must set it
 as false as the variables meaning is inverted.
 - Deprecated the option `requests`. It will be removed on my next version.
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,56 @@ The default levels that the middleware uses for logging are the following.
 
 The signature of the LoggerMiddleware class is the following:
 
-``LoggerMiddleware(LoggerInterface $logger, $logRequests = true, $logStatistics = false, array $thresholds = [])``
+``LoggerMiddleware(LoggerInterface $logger, HandlerInterface $handler = null, $onExceptionsOnly = false, $logStatistics = false)``
 
 - **logger** - The PSR-3 logger to use for logging.
+- **handler** - A HandlerInterface class that will be responsible for logging your request/response. Check Handlers sections.
 - **$onExceptionOnly** - By default the middleware is set to log every request and response. If you wish that to log only the requests and responses that you retrieve a status code above 4xx set this as true.
 - **logStatistics** - If you set logStatistics as true and this as true then guzzle will also log statistics about the requests.
-- **thresholds** - An array that you may use to change the thresholds of logging the responses. 
+
+### Handlers
+
+In order to make the middleware more flexible we allow the developers to initialize the middleware and pass a handler 
+during the construction. This handler must implement a `HandlerInterface` and it will be responsible for logging. 
+
+So now let's say that we have the following handler.
+
+``` php
+<?php
+
+namespace Gmponos\GuzzleLogger\Handler;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Log\LoggerInterface;
+
+final class SimpleHandler implements HandlerInterface
+{
+    public function log(LoggerInterface $logger, $value, array $options = [])
+    {
+        if ($value instanceof MessageInterface) {
+            $logger->debug('Guzzle HTTP message' . \GuzzleHttp\Psr7\str($value));
+        }
+
+        return;
+    }
+}
+```
+
+We can pass the handler above during construction of the middleware.
+
+```
+use Gmponos\GuzzleLogger\Middleware\LoggerMiddleware;
+use GuzzleHttp\HandlerStack;
+
+$logger = new Logger();  //A new PSR-3 Logger like Monolog
+$stack = HandlerStack::create(); // will create a stack stack with middlewares of guzzle already pushed inside of it.
+$stack->push(new LoggerMiddleware($logger, new SimpleHandler()));
+$client = new GuzzleHttp\Client([
+    'handler' => $stack,
+]);
+```
+
+If no handler is passed the middleware will initialize it's own handler. At the moment the default one is `ArrayHandler`
 
 ### Using options on each request
 
@@ -104,5 +148,5 @@ $ composer test
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
 
 ## Todo
- - Move the formatting of the Request/Response into separate classes and not inside the middleware class.
+ - Create more handlers to log request/responses
  - More tests

--- a/src/Handler/ArrayHandler.php
+++ b/src/Handler/ArrayHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Gmponos\GuzzleLogger\Handler;
+
+use Gmponos\GuzzleLogger\Handler\Exception\UnsupportedException;
+use Gmponos\GuzzleLogger\Handler\LogLevel\LogLevelStrategy;
+use Gmponos\GuzzleLogger\Handler\LogLevel\LogLevelStrategyInterface;
+use GuzzleHttp\TransferStats;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+
+final class ArrayHandler implements HandlerInterface
+{
+    /**
+     * @var LogLevelStrategyInterface
+     */
+    private $logLevelStrategy;
+
+    public function __construct(LogLevelStrategyInterface $logLevelStrategy = null)
+    {
+        $this->logLevelStrategy = $logLevelStrategy === null ? new LogLevelStrategy() : $logLevelStrategy;
+    }
+
+    public function log(LoggerInterface $logger, $value, array $options = [])
+    {
+        if ($value instanceof ResponseInterface) {
+            $context['response']['headers'] = $value->getHeaders();
+            $context['response']['statusCode'] = $value->getStatusCode();
+            $context['response']['version'] = 'HTTP/' . $value->getProtocolVersion();
+            $context['response']['message'] = $value->getReasonPhrase();
+
+            if ($value->getBody()->getSize() > 0) {
+                $context['response']['body'] = $this->formatBody($value, $options);
+            }
+
+            $level = $this->logLevelStrategy->getLevel($value, $options);
+            $logger->log($level, 'Guzzle HTTP response', $context);
+            return;
+        }
+
+        if ($value instanceof RequestInterface) {
+            $context['request']['method'] = $value->getMethod();
+            $context['request']['headers'] = $value->getHeaders();
+            $context['request']['uri'] = $value->getRequestTarget();
+            $context['request']['version'] = 'HTTP/' . $value->getProtocolVersion();
+
+            if ($value->getBody()->getSize() > 0) {
+                $context['request']['body'] = $this->formatBody($value, $options);
+            }
+
+            $level = $this->logLevelStrategy->getLevel($value, $options);
+            $logger->log($level, 'Guzzle HTTP request', $context);
+            return;
+        }
+
+        if ($value instanceof \Exception) {
+            $context['reason']['code'] = $value->getCode();
+            $context['reason']['message'] = $value->getMessage();
+            $context['reason']['line'] = $value->getLine();
+            $context['reason']['file'] = $value->getFile();
+
+            $level = $this->logLevelStrategy->getLevel($value, $options);
+            $logger->log($level, 'Guzzle HTTP exception', $context);
+            return;
+        }
+
+        if ($value instanceof TransferStats) {
+            $logger->debug('Guzzle HTTP statistics', [
+                'time' => $value->getTransferTime(),
+                'uri' => $value->getEffectiveUri(),
+            ]);
+
+            return;
+        }
+
+        throw new UnsupportedException();
+    }
+
+    private function formatBody(MessageInterface $message, array $options)
+    {
+        $stream = $message->getBody();
+        if ($stream->isSeekable() === false || $stream->isReadable() === false) {
+            return 'Body stream is not seekable/readable.';
+        }
+
+        if (isset($options['log']['sensitive']) && $options['log']['sensitive'] === true) {
+            return 'Body contains sensitive information therefore it is not included.';
+        }
+
+        if ($stream->getSize() >= 3500) {
+            return $stream->read(200) . ' (truncated...)';
+        }
+
+        $body = $stream->getContents();
+        $isJson = preg_grep('/application\/[\w\.\+]*(json)/', $message->getHeader('Content-Type'));
+        if (!empty($isJson)) {
+            $body = json_decode($body, true);
+        }
+
+        $stream->rewind();
+        return $body;
+    }
+}

--- a/src/Handler/ArrayHandler.php
+++ b/src/Handler/ArrayHandler.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @author George Mponos <gmponos@gmail.com>
+ */
 final class ArrayHandler implements HandlerInterface
 {
     /**
@@ -18,11 +21,20 @@ final class ArrayHandler implements HandlerInterface
      */
     private $logLevelStrategy;
 
+    /**
+     * @param LogLevelStrategyInterface|null $logLevelStrategy
+     */
     public function __construct(LogLevelStrategyInterface $logLevelStrategy = null)
     {
         $this->logLevelStrategy = $logLevelStrategy === null ? new LogLevelStrategy() : $logLevelStrategy;
     }
 
+    /**
+     * @param LoggerInterface $logger
+     * @param \Exception|TransferStats|MessageInterface $value
+     * @param array $options
+     * @return void
+     */
     public function log(LoggerInterface $logger, $value, array $options = [])
     {
         if ($value instanceof ResponseInterface) {
@@ -78,6 +90,11 @@ final class ArrayHandler implements HandlerInterface
         throw new UnsupportedException();
     }
 
+    /**
+     * @param MessageInterface $message
+     * @param array $options
+     * @return string|array
+     */
     private function formatBody(MessageInterface $message, array $options)
     {
         $stream = $message->getBody();

--- a/src/Handler/Exception/UnsupportedException.php
+++ b/src/Handler/Exception/UnsupportedException.php
@@ -2,6 +2,9 @@
 
 namespace Gmponos\GuzzleLogger\Handler\Exception;
 
+/**
+ * @author George Mponos <gmponos@gmail.com>
+ */
 final class UnsupportedException extends \RuntimeException
 {
 }

--- a/src/Handler/Exception/UnsupportedException.php
+++ b/src/Handler/Exception/UnsupportedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gmponos\GuzzleLogger\Handler\Exception;
+
+final class UnsupportedException extends \RuntimeException
+{
+}

--- a/src/Handler/HandlerInterface.php
+++ b/src/Handler/HandlerInterface.php
@@ -2,9 +2,21 @@
 
 namespace Gmponos\GuzzleLogger\Handler;
 
+use GuzzleHttp\TransferStats;
+use Psr\Http\Message\MessageInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Classes that will implement this interface are responsible to log the MessageInterface|\Exception|TransferStats
+ * passed as value.
+ */
 interface HandlerInterface
 {
+    /**
+     * @param LoggerInterface $logger
+     * @param MessageInterface|\Exception|TransferStats $value
+     * @param array $options
+     * @return void
+     */
     public function log(LoggerInterface $logger, $value, array $options = []);
 }

--- a/src/Handler/HandlerInterface.php
+++ b/src/Handler/HandlerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Gmponos\GuzzleLogger\Handler;
+
+use Psr\Log\LoggerInterface;
+
+interface HandlerInterface
+{
+    public function log(LoggerInterface $logger, $value, array $options = []);
+}

--- a/src/Handler/LogLevel/LogLevelStrategy.php
+++ b/src/Handler/LogLevel/LogLevelStrategy.php
@@ -2,7 +2,6 @@
 
 namespace Gmponos\GuzzleLogger\Handler\LogLevel;
 
-use Gmponos\GuzzleLogger\Handler\Exception\UnsupportedException;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -54,7 +53,7 @@ class LogLevelStrategy implements LogLevelStrategyInterface
             return LogLevel::DEBUG;
         }
 
-        throw new UnsupportedException('Could not retrieve the log level because of unknown message class.');
+        return LogLevel::DEBUG;
     }
 
     /**

--- a/src/Handler/LogLevel/LogLevelStrategy.php
+++ b/src/Handler/LogLevel/LogLevelStrategy.php
@@ -2,6 +2,7 @@
 
 namespace Gmponos\GuzzleLogger\Handler\LogLevel;
 
+use Gmponos\GuzzleLogger\Handler\Exception\UnsupportedException;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -53,7 +54,7 @@ class LogLevelStrategy implements LogLevelStrategyInterface
             return LogLevel::DEBUG;
         }
 
-        throw new \InvalidArgumentException('Could not retrieve the log level because of unknown message class.');
+        throw new UnsupportedException('Could not retrieve the log level because of unknown message class.');
     }
 
     /**

--- a/src/Handler/LogLevel/LogLevelStrategyInterface.php
+++ b/src/Handler/LogLevel/LogLevelStrategyInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Gmponos\GuzzleLogger\Handler\LogLevel;
+
+interface LogLevelStrategyInterface
+{
+    public function getLevel($value, array $options = []);
+}

--- a/src/Handler/LogLevel/LogLevelStrategyInterface.php
+++ b/src/Handler/LogLevel/LogLevelStrategyInterface.php
@@ -2,7 +2,20 @@
 
 namespace Gmponos\GuzzleLogger\Handler\LogLevel;
 
+use GuzzleHttp\TransferStats;
+use Psr\Http\Message\MessageInterface;
+
+/**
+ * Classes that will implement this interface will be able to determine the log level.
+ */
 interface LogLevelStrategyInterface
 {
+    /**
+     * Returns the log level.
+     *
+     * @param MessageInterface|\Exception|TransferStats $value
+     * @param array $options
+     * @return string
+     */
     public function getLevel($value, array $options = []);
 }

--- a/src/Handler/StringHandler.php
+++ b/src/Handler/StringHandler.php
@@ -24,7 +24,7 @@ final class StringHandler implements HandlerInterface
      */
     public function __construct(LogLevelStrategyInterface $logLevelStrategy = null)
     {
-        $this->logLevelStrategy = $logLevelStrategy = null ? new LogLevelStrategy() : $logLevelStrategy;
+        $this->logLevelStrategy = $logLevelStrategy === null ? new LogLevelStrategy() : $logLevelStrategy;
     }
 
     /**

--- a/src/Handler/StringHandler.php
+++ b/src/Handler/StringHandler.php
@@ -7,6 +7,8 @@ use Gmponos\GuzzleLogger\Handler\LogLevel\LogLevelStrategy;
 use Gmponos\GuzzleLogger\Handler\LogLevel\LogLevelStrategyInterface;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -39,12 +41,20 @@ final class StringHandler implements HandlerInterface
         if ($value instanceof MessageInterface) {
             // we do not allow to record the message if the body is not seekable.
             if ($value->getBody()->isSeekable() === false || $value->getBody()->isReadable() === false) {
-                $logger->warning('String handler can not log request/response because the body is not seekable/rewindable.');
+                $logger->warning('String handler can not log request/response because the body is not seekable/readable.');
                 return;
             }
 
-            $logger->log($level, 'Guzzle HTTP message', ['message' => \GuzzleHttp\Psr7\str($value)]);
-            return;
+            $str = \GuzzleHttp\Psr7\str($value);
+            if ($value instanceof RequestInterface) {
+                $logger->log($level, 'Guzzle HTTP request:' . "\n" . $str);
+                return;
+            }
+
+            if ($value instanceof ResponseInterface) {
+                $logger->log($level, 'Guzzle HTTP response:' . "\n" . $str);
+                return;
+            }
         }
 
         if ($value instanceof \Exception) {

--- a/src/Handler/StringHandler.php
+++ b/src/Handler/StringHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Gmponos\GuzzleLogger\Handler;
+
+use Gmponos\GuzzleLogger\Handler\Exception\UnsupportedException;
+use Gmponos\GuzzleLogger\Handler\LogLevel\LogLevelStrategy;
+use Gmponos\GuzzleLogger\Handler\LogLevel\LogLevelStrategyInterface;
+use GuzzleHttp\TransferStats;
+use Psr\Http\Message\MessageInterface;
+use Psr\Log\LoggerInterface;
+
+final class StringHandler implements HandlerInterface
+{
+    /**
+     * @var LogLevelStrategyInterface
+     */
+    private $logLevelStrategy;
+
+    public function __construct(LogLevelStrategyInterface $logLevelStrategy = null)
+    {
+        $this->logLevelStrategy = $logLevelStrategy = null ? new LogLevelStrategy() : $logLevelStrategy;
+    }
+
+    public function log(LoggerInterface $logger, $value, array $options = [])
+    {
+        $level = $this->logLevelStrategy->getLevel($value, $options);
+        if ($value instanceof MessageInterface) {
+            $logger->log($level, 'Guzzle HTTP message', ['message' => \GuzzleHttp\Psr7\str($value)]);
+            return;
+        }
+
+        if ($value instanceof \Exception) {
+            $logger->log($level, 'Guzzle HTTP exception', ['exception' => $value]);
+            return;
+        }
+
+        if ($value instanceof TransferStats) {
+            $logger->log($level, sprintf(
+                'Guzzle HTTP transfer time: %s for uri: %s',
+                $value->getTransferTime(),
+                $value->getEffectiveUri()
+            ));
+            return;
+        }
+
+        throw new UnsupportedException();
+    }
+}

--- a/src/Middleware/LoggerMiddleware.php
+++ b/src/Middleware/LoggerMiddleware.php
@@ -19,11 +19,15 @@ use Psr\Log\LoggerInterface;
 class LoggerMiddleware
 {
     /**
-     * @var bool Whether or not to log requests as they are made.
+     * Whether or not to log requests as they are made.
+     *
+     * @var bool
      */
     private $onExceptionOnly;
 
     /**
+     * Whether or not to log statistics.
+     *
      * @var bool
      */
     private $logStatistics;
@@ -144,7 +148,6 @@ class LoggerMiddleware
         $options = array_merge([
             'on_exception_only' => $this->onExceptionOnly,
             'statistics' => $this->logStatistics,
-            'sensitive' => false,
         ], $options);
 
         $this->onExceptionOnly = $options['on_exception_only'];

--- a/src/Middleware/LoggerMiddleware.php
+++ b/src/Middleware/LoggerMiddleware.php
@@ -3,16 +3,18 @@
 namespace Gmponos\GuzzleLogger\Middleware;
 
 use Closure;
+use Gmponos\GuzzleLogger\Handler\ArrayHandler;
+use Gmponos\GuzzleLogger\Handler\HandlerInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\TransferStats;
-use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 
 /**
  * A class to log HTTP Requests and Responses of Guzzle.
+ *
+ * @author George Mponos <gmponos@gmail.com>
  */
 class LoggerMiddleware
 {
@@ -27,19 +29,9 @@ class LoggerMiddleware
     private $logStatistics;
 
     /**
-     * @var array
+     * @var HandlerInterface
      */
-    private $thresholds;
-
-    /**
-     * @var array
-     */
-    private $logCodeLevel = [];
-
-    /**
-     * @var bool
-     */
-    private $sensitive;
+    private $normalizer;
 
     /**
      * @var LoggerInterface
@@ -50,23 +42,20 @@ class LoggerMiddleware
      * Creates a callable middleware for logging requests and responses.
      *
      * @param LoggerInterface $logger
+     * @param HandlerInterface $normalizer
      * @param bool $onExceptionOnly The request and the response will be logged only in cases there is an exception or if they status code exceeds the thresholds.
      * @param bool $logStatistics If this is true an extra row will be added that will contain some HTTP statistics.
-     * @param array $thresholds
      */
     public function __construct(
         LoggerInterface $logger,
+        HandlerInterface $normalizer = null,
         $onExceptionOnly = false,
-        $logStatistics = false,
-        array $thresholds = []
+        $logStatistics = false
     ) {
         $this->logger = $logger;
         $this->onExceptionOnly = $onExceptionOnly;
         $this->logStatistics = $logStatistics;
-        $this->thresholds = array_merge([
-            'error' => 499,
-            'warning' => 399,
-        ], $thresholds);
+        $this->normalizer = $normalizer === null ? new ArrayHandler() : $normalizer;
     }
 
     /**
@@ -81,117 +70,36 @@ class LoggerMiddleware
             $this->setOptions($options);
 
             if ($this->onExceptionOnly === false) {
-                $this->logRequest($request);
+                $this->normalizer->log($this->logger, $request, $options);
                 if ($this->logStatistics && !isset($options['on_stats'])) {
-                    $options['on_stats'] = $this->logStatistics();
+                    $options['on_stats'] = function (TransferStats $stats) {
+                        $this->normalizer->log($this->logger, $stats);
+                    };
                 }
             }
 
-            return $handler($request, $options)
-                ->then(
-                    $this->handleSuccess($request),
-                    $this->handleFailure($request)
-                );
+            return $handler($request, $options)->then(
+                $this->handleSuccess($request, $options),
+                $this->handleFailure($request, $options)
+            );
         };
-    }
-
-    /**
-     * Returns the default log level for a response.
-     *
-     * @param RequestInterface|ResponseInterface|\Exception $message
-     * @return string LogLevel
-     */
-    private function getLogLevel($message = null)
-    {
-        if ($message === null || ($message instanceof \Exception)) {
-            return LogLevel::CRITICAL;
-        }
-
-        if ($message instanceof RequestInterface) {
-            return LogLevel::DEBUG;
-        }
-
-        if ($message instanceof ResponseInterface) {
-            $code = $message->getStatusCode();
-            if ($code === 0) {
-                return LogLevel::CRITICAL;
-            }
-
-            if (isset($this->logCodeLevel[$code])) {
-                return $this->logCodeLevel[$code];
-            }
-
-            if ($this->thresholds['error'] !== null && $code > $this->thresholds['error']) {
-                return LogLevel::CRITICAL;
-            }
-
-            if ($this->thresholds['warning'] !== null && $code > $this->thresholds['warning']) {
-                return LogLevel::ERROR;
-            }
-
-            return LogLevel::DEBUG;
-        }
-
-        throw new \InvalidArgumentException('Could not retrieve the log level because of unknown message class.');
-    }
-
-    /**
-     * @param RequestInterface $request
-     * @return void
-     */
-    private function logRequest(RequestInterface $request)
-    {
-        $this->logger->log(
-            $this->getLogLevel($request),
-            'Guzzle HTTP request',
-            $this->withRequestContext($request)
-        );
-    }
-
-    /**
-     * @return Closure
-     */
-    private function logStatistics()
-    {
-        return function (TransferStats $stats) {
-            $this->logger->debug('Guzzle HTTP statistics', [
-                'time' => $stats->getTransferTime(),
-                'uri' => $stats->getEffectiveUri(),
-            ]);
-        };
-    }
-
-    /**
-     * @param ResponseInterface $response
-     * @return void
-     */
-    private function logResponse(ResponseInterface $response)
-    {
-        $this->logger->log(
-            $this->getLogLevel($response),
-            'Guzzle HTTP response',
-            $this->withResponseContext($response)
-        );
     }
 
     /**
      * Returns a function which is handled when a request was successful.
      *
      * @param RequestInterface $request
+     * @param array $options
      * @return Closure
      */
-    private function handleSuccess(RequestInterface $request)
+    private function handleSuccess(RequestInterface $request, array $options)
     {
-        return function (ResponseInterface $response) use ($request) {
+        return function (ResponseInterface $response) use ($request, $options) {
+            // On exception only is true then it must not log the response since it was successful.
             if ($this->onExceptionOnly === false) {
-                $this->logResponse($response);
-                return $response;
+                $this->normalizer->log($this->logger, $response, $options);
             }
 
-            if ($response->getStatusCode() > $this->thresholds['warning']) {
-                $this->logRequest($request);
-                $this->logResponse($response);
-            }
             return $response;
         };
     }
@@ -200,108 +108,25 @@ class LoggerMiddleware
      * Returns a function which is handled when a request was rejected.
      *
      * @param RequestInterface $request
+     * @param array $options
      * @return Closure
      */
-    private function handleFailure(RequestInterface $request)
+    private function handleFailure(RequestInterface $request, array $options)
     {
-        return function (\Exception $reason) use ($request) {
+        return function (\Exception $reason) use ($request, $options) {
             if ($this->onExceptionOnly === true) {
-                $this->logRequest($request);
+                // This means that the request was not logged and since an exception happened we need to log the request too.
+                $this->normalizer->log($this->logger, $request, $options);
             }
 
             if ($reason instanceof RequestException && $reason->hasResponse()) {
-                $this->logResponse($reason->getResponse());
+                $this->normalizer->log($this->logger, $reason->getResponse(), $options);
                 return \GuzzleHttp\Promise\rejection_for($reason);
             }
 
-            $this->logger->log($this->getLogLevel($reason), 'Guzzle HTTP exception', $this->withReasonContext($reason));
+            $this->normalizer->log($this->logger, $reason, $options);
             return \GuzzleHttp\Promise\rejection_for($reason);
         };
-    }
-
-    /**
-     * Merges and return the response context
-     *
-     * @param \Exception $reason
-     * @param array $context
-     * @return array
-     */
-    private function withReasonContext(\Exception $reason, array $context = [])
-    {
-        $context['reason']['code'] = $reason->getCode();
-        $context['reason']['message'] = $reason->getMessage();
-        return $context;
-    }
-
-    /**
-     * Merges and return the request context
-     *
-     * @param RequestInterface $request
-     * @param array $context
-     * @return array
-     */
-    private function withRequestContext(RequestInterface $request, array $context = [])
-    {
-        $context['request']['method'] = $request->getMethod();
-        $context['request']['headers'] = $request->getHeaders();
-        $context['request']['uri'] = $request->getRequestTarget();
-        $context['request']['version'] = 'HTTP/' . $request->getProtocolVersion();
-
-        if ($request->getBody()->getSize() !== 0) {
-            $context['request']['body'] = $this->getBody($request);
-        }
-
-        return $context;
-    }
-
-    /**
-     * Merges and return the response context
-     *
-     * @param ResponseInterface $response
-     * @param array $context
-     * @return array
-     */
-    private function withResponseContext(ResponseInterface $response, array $context = [])
-    {
-        $context['response']['headers'] = $response->getHeaders();
-        $context['response']['statusCode'] = $response->getStatusCode();
-        $context['response']['version'] = 'HTTP/' . $response->getProtocolVersion();
-        $context['response']['message'] = $response->getReasonPhrase();
-
-        if ($response->getBody()->getSize() !== 0) {
-            $context['response']['body'] = $this->getBody($response);
-        }
-
-        return $context;
-    }
-
-    /**
-     * @param MessageInterface $message
-     * @return string
-     */
-    private function getBody(MessageInterface $message)
-    {
-        $stream = $message->getBody();
-        if ($stream->isSeekable() === false || $stream->isReadable() === false) {
-            return 'Body stream is not seekable/readable.';
-        }
-
-        if ($this->sensitive === true) {
-            return 'Body contains sensitive information therefore it is not included.';
-        }
-
-        if ($stream->getSize() >= 3500) {
-            return $stream->read(200) . ' (truncated...)';
-        }
-
-        $body = $stream->getContents();
-        $isJson = preg_grep('/application\/[\w\.\+]*(json)/', $message->getHeader('Content-Type'));
-        if (!empty($isJson)) {
-            $body = json_decode($body, true);
-        }
-
-        $stream->rewind();
-        return $body;
     }
 
     /**
@@ -315,28 +140,14 @@ class LoggerMiddleware
         }
 
         $options = $options['log'];
-        if (isset($options['requests'])) {
-            @trigger_error('Using option "requests" is deprecated and it will be removed on the next version. Use "on_exception_only"', E_USER_DEPRECATED);
-            if (!isset($options['on_exception_only'])) {
-                $options['on_exception_only'] = !$options['requests'];
-            }
-        }
 
-        $defaults = [
+        $options = array_merge([
             'on_exception_only' => $this->onExceptionOnly,
             'statistics' => $this->logStatistics,
-            'warning_threshold' => 399,
-            'error_threshold' => 499,
-            'levels' => [],
             'sensitive' => false,
-        ];
+        ], $options);
 
-        $options = array_merge($defaults, $options);
-        $this->logCodeLevel = $options['levels'];
-        $this->thresholds['warning'] = $options['warning_threshold'];
-        $this->thresholds['error'] = $options['error_threshold'];
         $this->onExceptionOnly = $options['on_exception_only'];
         $this->logStatistics = $options['statistics'];
-        $this->sensitive = $options['sensitive'];
     }
 }

--- a/tests/Unit/Handler/StringHandlerTest.php
+++ b/tests/Unit/Handler/StringHandlerTest.php
@@ -37,8 +37,8 @@ final class StringHandlerTest extends \PHPUnit_Framework_TestCase
         $this->handler->log($this->logger, new Request('get', \GuzzleHttp\Psr7\uri_for('www.test.com')));
         $this->assertCount(1, $this->logger->history);
         $this->assertSame(LogLevel::DEBUG, $this->logger->history[0]['level']);
-        $this->assertSame('Guzzle HTTP message', $this->logger->history[0]['message']);
-        $this->assertArrayHasKey('message', $this->logger->history[0]['context']);
+        $this->assertStringStartsWith('Guzzle HTTP request:', $this->logger->history[0]['message']);
+        $this->assertCount(0, $this->logger->history[0]['context']);
     }
 
     /**

--- a/tests/Unit/Handler/StringHandlerTest.php
+++ b/tests/Unit/Handler/StringHandlerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Gmponos\GuzzleLogger\Test\Unit\Handler;
+
+use Gmponos\GuzzleLogger\Handler\HandlerInterface;
+use Gmponos\GuzzleLogger\Handler\StringHandler;
+use Gmponos\GuzzleLogger\Test\TestApp\HistoryLogger;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\TransferStats;
+use Psr\Log\LogLevel;
+
+final class StringHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HandlerInterface
+     */
+    private $handler;
+
+    /**
+     * @var HistoryLogger
+     */
+    private $logger;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->logger = new HistoryLogger();
+        $this->handler = new StringHandler();
+    }
+
+    /**
+     * @test
+     */
+    public function handlerWithValueException()
+    {
+        $this->handler->log($this->logger, new \Exception());
+        $this->assertCount(1, $this->logger->history);
+        $this->assertSame(LogLevel::CRITICAL, $this->logger->history[0]['level']);
+        $this->assertSame('Guzzle HTTP exception', $this->logger->history[0]['message']);
+    }
+
+    /**
+     * @test
+     */
+    public function handlerWithValueTransferStats()
+    {
+        $this->handler->log($this->logger, new TransferStats(
+            new Request('get', 'www.test.com'),
+            new Response(),
+            0.01
+        ));
+        $this->assertCount(1, $this->logger->history);
+        $this->assertSame(LogLevel::DEBUG, $this->logger->history[0]['level']);
+        $this->assertSame('Guzzle HTTP transfer time: 0.01 for uri: www.test.com', $this->logger->history[0]['message']);
+    }
+
+    /**
+     * @test
+     * @expectedException \Gmponos\GuzzleLogger\Handler\Exception\UnsupportedException
+     */
+    public function handlerWithValueThatDoesNotMatchMustThrowException()
+    {
+        $this->handler->log($this->logger, new \stdClass());
+    }
+}

--- a/tests/Unit/Handler/StringHandlerTest.php
+++ b/tests/Unit/Handler/StringHandlerTest.php
@@ -32,6 +32,18 @@ final class StringHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function handlerWithValueAsRequest()
+    {
+        $this->handler->log($this->logger, new Request('get', \GuzzleHttp\Psr7\uri_for('www.test.com')));
+        $this->assertCount(1, $this->logger->history);
+        $this->assertSame(LogLevel::DEBUG, $this->logger->history[0]['level']);
+        $this->assertSame('Guzzle HTTP message', $this->logger->history[0]['message']);
+        $this->assertArrayHasKey('message', $this->logger->history[0]['context']);
+    }
+
+    /**
+     * @test
+     */
     public function handlerWithValueException()
     {
         $this->handler->log($this->logger, new \Exception());

--- a/tests/Unit/LoggerMiddlewareTest.php
+++ b/tests/Unit/LoggerMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 namespace Gmponos\GuzzleLogger\Test\Unit;
 
+use Gmponos\GuzzleLogger\Handler\ArrayHandler;
 use Gmponos\GuzzleLogger\Middleware\LoggerMiddleware;
 use Gmponos\GuzzleLogger\Test\TestApp\HistoryLogger;
 use GuzzleHttp\Client;
@@ -56,7 +57,7 @@ final class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
     private function createClient(array $options = [])
     {
         $stack = HandlerStack::create($this->mockHandler);
-        $stack->unshift(new LoggerMiddleware($this->logger));
+        $stack->unshift(new LoggerMiddleware($this->logger, new ArrayHandler()));
         return new Client(
             array_merge([
                 'handler' => $stack,
@@ -90,7 +91,7 @@ final class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->appendResponse(200)
             ->createClient([
                 'log' => [
-                    'requests' => false,
+                    'on_exception_only' => true,
                 ],
             ])
             ->get('/');
@@ -102,7 +103,7 @@ final class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->appendResponse(200)->createClient()
             ->get('/', [
                 'log' => [
-                    'requests' => false,
+                    'on_exception_only' => true,
                 ],
             ]);
 
@@ -120,7 +121,7 @@ final class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
                 ->appendResponse(500);
             $client = $this->createClient([
                 'log' => [
-                    'requests' => false,
+                    'on_exception_only' => true,
                 ],
             ]);
             $client->get('/');
@@ -375,11 +376,11 @@ final class LoggerMiddlewareTest extends \PHPUnit_Framework_TestCase
             ->createClient([
                 'log' => [
                     'levels' => [
-                        300 => 'warning',
-                        301 => 'warning',
-                        402 => 'warning',
-                        403 => 'warning',
-                        500 => 'warning',
+                        300 => LogLevel::WARNING,
+                        301 => LogLevel::WARNING,
+                        402 => LogLevel::WARNING,
+                        403 => LogLevel::WARNING,
+                        500 => LogLevel::WARNING,
                     ],
                 ],
             ])

--- a/tests/Unit/Middleware/LoggerMiddlewareTest.php
+++ b/tests/Unit/Middleware/LoggerMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Gmponos\GuzzleLogger\Test\Unit;
+namespace Gmponos\GuzzleLogger\Test\Unit\Middleware;
 
 use Gmponos\GuzzleLogger\Handler\ArrayHandler;
 use Gmponos\GuzzleLogger\Middleware\LoggerMiddleware;


### PR DESCRIPTION
closes https://github.com/gmponos/guzzle-log-middleware/issues/6

Created a way in order to allow developers to pass their own way of Logging guzzle request/responses.

This new way allows the developer to pass to the middleware a HandlerInterface.

This Handler must be responsible for the way that the request/response/exception/transfer stats will be logged.