### PR TITLE
Make MultiRecordArrayHandler and StringHandler classes not final

### DIFF
--- a/src/Handler/MultiRecordArrayHandler.php
+++ b/src/Handler/MultiRecordArrayHandler.php
@@ -15,7 +15,7 @@ use Psr\Log\LoggerInterface;
 /**
  * @author George Mponos <gmponos@gmail.com>
  */
-final class MultiRecordArrayHandler extends AbstractHandler
+class MultiRecordArrayHandler extends AbstractHandler
 {
     /**
      * @var int

--- a/src/Handler/MultiRecordArrayHandler.php
+++ b/src/Handler/MultiRecordArrayHandler.php
@@ -60,7 +60,7 @@ class MultiRecordArrayHandler extends AbstractHandler
         }
     }
 
-    private function logRequest(LoggerInterface $logger, RequestInterface $request, array $options): void
+    protected function logRequest(LoggerInterface $logger, RequestInterface $request, array $options): void
     {
         $context['request']['method'] = $request->getMethod();
         $context['request']['headers'] = $request->getHeaders();
@@ -81,7 +81,7 @@ class MultiRecordArrayHandler extends AbstractHandler
      * @param array $options
      * @return void
      */
-    private function logResponse(LoggerInterface $logger, ResponseInterface $response, array $options): void
+    protected function logResponse(LoggerInterface $logger, ResponseInterface $response, array $options): void
     {
         $context['response']['headers'] = $response->getHeaders();
         $context['response']['status_code'] = $response->getStatusCode();
@@ -102,7 +102,7 @@ class MultiRecordArrayHandler extends AbstractHandler
      * @param array $options
      * @return void
      */
-    private function logReason(LoggerInterface $logger, ?Exception $exception, array $options): void
+    protected function logReason(LoggerInterface $logger, ?Exception $exception, array $options): void
     {
         if ($exception === null) {
             return;
@@ -123,7 +123,7 @@ class MultiRecordArrayHandler extends AbstractHandler
      * @param array $options
      * @return void
      */
-    private function logStats(LoggerInterface $logger, TransferStats $stats, array $options): void
+    protected function logStats(LoggerInterface $logger, TransferStats $stats, array $options): void
     {
         $this->logLevelStrategy->getLevel($stats, $options);
         $logger->debug('Guzzle HTTP statistics', [

--- a/src/Handler/MultiRecordArrayHandler.php
+++ b/src/Handler/MultiRecordArrayHandler.php
@@ -137,7 +137,7 @@ class MultiRecordArrayHandler extends AbstractHandler
      * @param array $options
      * @return string|array
      */
-    private function formatBody(MessageInterface $message, array $options)
+    protected function formatBody(MessageInterface $message, array $options)
     {
         $stream = $message->getBody();
         if ($stream->isSeekable() === false || $stream->isReadable() === false) {

--- a/src/Handler/StringHandler.php
+++ b/src/Handler/StringHandler.php
@@ -14,7 +14,7 @@ use Psr\Log\LoggerInterface;
 /**
  * @author George Mponos <gmponos@gmail.com>
  */
-final class StringHandler extends AbstractHandler
+class StringHandler extends AbstractHandler
 {
     public function __construct(LogLevelStrategyInterface $logLevelStrategy = null)
     {


### PR DESCRIPTION
Unless there is any reason for them to be final?
My use case - I want to extend MultiRecordArrayHandler class and overwrite formatBody method to clear some sensitive request/response data.