### PR TITLE
Allow psr/log in version 2 and 3, like guzzlehttp/guzzle do it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.1 || ^7.0.1",
         "guzzlehttp/psr7": "^1.7 || ^2.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "~0.12.32",

--- a/src/Handler/StringHandler.php
+++ b/src/Handler/StringHandler.php
@@ -53,7 +53,7 @@ final class StringHandler extends AbstractHandler
             return;
         }
 
-        $str = \GuzzleHttp\Psr7\str($value);
+        $str = \GuzzleHttp\Psr7\Message::toString($value);
 
         $level = $this->logLevelStrategy->getLevel($value, $options);
         $logger->log($level, 'Guzzle HTTP request:' . "\n" . $str);
@@ -67,7 +67,7 @@ final class StringHandler extends AbstractHandler
             return;
         }
 
-        $str = \GuzzleHttp\Psr7\str($value);
+        $str = \GuzzleHttp\Psr7\Message::toString($value);
 
         $level = $this->logLevelStrategy->getLevel($value, $options);
         $logger->log($level, 'Guzzle HTTP response:' . "\n" . $str);


### PR DESCRIPTION
I would like to use the psr/log in version 3.0, this changes should do the job to be compatible with version 1, 2 and 3