### PR TITLE
Feature/add guzzle7 latest versions compatibility

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-# Funding file
-github: [gmponos]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All Notable changes to `gmponos/guzzle_logger` will be documented in this file
+All Notable changes to `softonic/guzzle_logger` will be documented in this file
 
 ## 2.2.0 - 2021-04-04
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Guzzle Log Middleware
 
-[![codecov](https://codecov.io/gh/gmponos/guzzle-log-middleware/branch/master/graph/badge.svg)](https://codecov.io/gh/gmponos/guzzle-log-middleware)
-[![Total Downloads](https://img.shields.io/packagist/dt/gmponos/guzzle_logger.svg)](https://packagist.org/packages/gmponos/guzzle_logger)
-[![Build Status](https://travis-ci.org/gmponos/guzzle-log-middleware.svg?branch=master)](https://travis-ci.org/gmponos/guzzle-log-middleware)
-[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/gmponos/monolog-slack/blob/master/LICENSE.md)
+[![codecov](https://codecov.io/gh/softonic/guzzle-log-middleware/branch/master/graph/badge.svg)](https://codecov.io/gh/softonic/guzzle-log-middleware)
+[![Total Downloads](https://img.shields.io/packagist/dt/softonic/guzzle_logger.svg)](https://packagist.org/packages/softonic/guzzle_logger)
+[![Build Status](https://travis-ci.org/softonic/guzzle-log-middleware.svg?branch=master)](https://travis-ci.org/softonic/guzzle-log-middleware)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/softonic/monolog-slack/blob/master/LICENSE.md)
 
 This is a middleware for [guzzle](https://github.com/guzzle/guzzle) that will help you automatically log every request 
 and response using a PSR-3 logger.
@@ -15,7 +15,7 @@ The middleware is functional with version 6 of Guzzle.
 Via Composer
 
 ``` bash
-$ composer require gmponos/guzzle_logger
+$ composer require softonic/guzzle_logger
 ```
 
 ## Usage
@@ -179,7 +179,6 @@ $ composer test
 
 ## Credits
 
-- [George Mponos](gmponos@gmail.com)
 - [Contributors](../../contributors)
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.1 || ^7.0.1",
         "psr/log": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "gmponos/guzzle_logger",
+    "name": "softonic/guzzle_logger",
     "description": "A Guzzle middleware to log request and responses automatically",
     "keywords": [
         "psr3",
@@ -8,13 +8,7 @@
         "logging"
     ],
     "license": "MIT",
-    "homepage": "https://github.com/gmponos/guzzle-log-middleware",
-    "authors": [
-        {
-            "name": "George Mponos",
-            "email": "gmponos@gmail.com"
-        }
-    ],
+    "homepage": "https://github.com/softonic/guzzle-log-middleware",
     "autoload": {
         "psr-4": {
             "GuzzleLogMiddleware\\": "src/"
@@ -28,7 +22,8 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.1 || ^7.0.1",
+        "colinodell/psr-testlogger": "^1.3",
+        "guzzlehttp/guzzle": "^6.1 || ^7",
         "guzzlehttp/psr7": "^1.7 || ^2.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0"
     },

--- a/src/Handler/AbstractHandler.php
+++ b/src/Handler/AbstractHandler.php
@@ -7,9 +7,6 @@ namespace GuzzleLogMiddleware\Handler;
 use GuzzleLogMiddleware\Handler\LogLevelStrategy\FixedStrategy;
 use GuzzleLogMiddleware\Handler\LogLevelStrategy\LogLevelStrategyInterface;
 
-/**
- * @author George Mponos <gmponos@gmail.com>
- */
 abstract class AbstractHandler implements HandlerInterface
 {
     /**

--- a/src/Handler/HandlerInterface.php
+++ b/src/Handler/HandlerInterface.php
@@ -14,8 +14,6 @@ use Throwable;
  * Classes that will implement this interface are responsible
  * to log the MessageInterface|\Throwable|TransferStats that are
  * passed as values.
- *
- * @author George Mponos <gmponos@gmail.com>
  */
 interface HandlerInterface
 {

--- a/src/Handler/LogLevelStrategy/FixedStrategy.php
+++ b/src/Handler/LogLevelStrategy/FixedStrategy.php
@@ -9,9 +9,6 @@ use GuzzleHttp\TransferStats;
 use Psr\Http\Message\MessageInterface;
 use Psr\Log\LogLevel;
 
-/**
- * @author George Mponos <gmponos@gmail.com>
- */
 final class FixedStrategy implements LogLevelStrategyInterface
 {
     /**

--- a/src/Handler/LogLevelStrategy/StatusCodeStrategy.php
+++ b/src/Handler/LogLevelStrategy/StatusCodeStrategy.php
@@ -7,9 +7,6 @@ namespace GuzzleLogMiddleware\Handler\LogLevelStrategy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LogLevel;
 
-/**
- * @author George Mponos <gmponos@gmail.com>
- */
 final class StatusCodeStrategy implements LogLevelStrategyInterface
 {
     /**

--- a/src/Handler/LogLevelStrategy/ThresholdStrategy.php
+++ b/src/Handler/LogLevelStrategy/ThresholdStrategy.php
@@ -9,9 +9,6 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LogLevel;
 
-/**
- * @author George Mponos <gmponos@gmail.com>
- */
 final class ThresholdStrategy implements LogLevelStrategyInterface
 {
     public const INFORMATIONAL = '1xx';

--- a/src/Handler/MultiRecordArrayHandler.php
+++ b/src/Handler/MultiRecordArrayHandler.php
@@ -13,9 +13,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
-/**
- * @author George Mponos <gmponos@gmail.com>
- */
 final class MultiRecordArrayHandler extends AbstractHandler
 {
     /**

--- a/src/Handler/StringHandler.php
+++ b/src/Handler/StringHandler.php
@@ -11,9 +11,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
-/**
- * @author George Mponos <gmponos@gmail.com>
- */
 final class StringHandler extends AbstractHandler
 {
     public function __construct(LogLevelStrategyInterface $logLevelStrategy = null)

--- a/src/LogMiddleware.php
+++ b/src/LogMiddleware.php
@@ -15,8 +15,6 @@ use Psr\Log\LoggerInterface;
 
 /**
  * A class to log HTTP Requests and Responses of Guzzle.
- *
- * @author George Mponos <gmponos@gmail.com>
  */
 final class LogMiddleware
 {
@@ -109,14 +107,14 @@ final class LogMiddleware
      */
     private function handleFailure(RequestInterface $request, array $options): callable
     {
-        return function (\Exception $reason) use ($request, $options) {
+        return function ($reason) use ($request, $options) {
             if ($reason instanceof RequestException && $reason->hasResponse() === true) {
                 $this->handler->log($this->logger, $request, $reason->getResponse(), $reason, $this->stats, $options);
-                return \GuzzleHttp\Promise\rejection_for($reason);
+                return \GuzzleHttp\Promise\Create::rejectionFor($reason);
             }
 
             $this->handler->log($this->logger, $request, null, $reason, $this->stats, $options);
-            return \GuzzleHttp\Promise\rejection_for($reason);
+            return \GuzzleHttp\Promise\Create::rejectionFor($reason);
         };
     }
 

--- a/tests/AbstractLoggerMiddlewareTest.php
+++ b/tests/AbstractLoggerMiddlewareTest.php
@@ -15,7 +15,7 @@ use GuzzleLogMiddleware\LogMiddleware;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Log\Test\TestLogger;
+use ColinODell\PsrTestLogger\TestLogger;
 
 abstract class AbstractLoggerMiddlewareTest extends TestCase
 {


### PR DESCRIPTION
Updated library to be able to use latest Guzzle 7.x versions. Due to gmponos not being updated during two years with the fixes in PRs without being merged, moved the library to softonic vendor to maintain it.